### PR TITLE
Registrar fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 /yarn-error.log
 /node_modules
 /out
+
+# dapptools
+**/hevm.cache.*

--- a/contracts/Registrar.sol
+++ b/contracts/Registrar.sol
@@ -26,7 +26,7 @@ contract Registrar {
     uint256 public constant tokenId = uint256(keccak256("radicle"));
 
     /// Registration fee in *Radicle* (uRads).
-    uint256 public registrationFeeRad = 1e18;
+    uint256 public registrationFee = 1e18;
 
     // --- LOGS ---
 
@@ -74,18 +74,18 @@ contract Registrar {
     // --- USER FACING METHODS ---
 
     /// Register a subdomain (with the default resolver and ttl)
-    function registerRad(string memory name, address owner) public {
-        registerRad(name, owner, ens.resolver(radNode), 0);
+    function register(string memory name, address owner) public {
+        register(name, owner, ens.resolver(radNode), 0);
     }
 
     /// Register a subdomain (with a custom resolver and ttl)
-    function registerRad(string memory name, address owner, address resolver, uint64 ttl) public {
-        uint256 fee   = registrationFeeRad;
+    function register(string memory name, address owner, address resolver, uint64 ttl) public {
+        uint256 fee   = registrationFee;
         bytes32 label = keccak256(bytes(name));
 
-        require(rad.balanceOf(msg.sender) >= fee, "Registrar::registerRad: insufficient rad balance");
-        require(available(name), "Registrar::registerRad: name has already been registered");
-        require(valid(name), "Registrar::registerRad: invalid name");
+        require(rad.balanceOf(msg.sender) >= fee, "Registrar::register: insufficient rad balance");
+        require(available(name), "Registrar::register: name has already been registered");
+        require(valid(name), "Registrar::register: invalid name");
 
         rad.burnFrom(msg.sender, fee);
         ens.setSubnodeRecord(radNode, label, owner, resolver, ttl);
@@ -137,7 +137,7 @@ contract Registrar {
 
     /// Set a new registration fee
     function setRegistrationFee(uint256 amt) public adminOnly {
-        registrationFeeRad = amt;
+        registrationFee = amt;
         emit RegistrationFeeChanged(amt);
     }
 

--- a/contracts/Registrar.sol
+++ b/contracts/Registrar.sol
@@ -94,7 +94,7 @@ contract Registrar {
     function setDomainOwner(address newOwner) public adminOnly {
         IERC721 ethRegistrar = IERC721(ens.owner(ethNode));
 
-        ens.setRecord(radNode, newOwner, newOwner, 0);
+        ens.setOwner(radNode, newOwner);
         ethRegistrar.transferFrom(address(this), newOwner, tokenId);
 
         emit DomainOwnershipChanged(newOwner);

--- a/contracts/Registrar.sol
+++ b/contracts/Registrar.sol
@@ -10,12 +10,6 @@ contract Registrar {
     /// The ENS registry.
     ENS public immutable ens;
 
-    /// The price oracle.
-    address public oracleAddress;
-
-    /// The Rad/Eth exchange.
-    address public exchangeAddress;
-
     /// The Radicle ERC20 token.
     ERC20Burnable public immutable rad;
 
@@ -24,9 +18,6 @@ contract Registrar {
 
     /// The token ID for the node in the `eth` TLD, eg. sha256("radicle").
     uint256 public immutable tokenId;
-
-    /// Registration fee in *USD*.
-    uint256 public registrationFeeUsd = 10;
 
     /// Registration fee in *Radicle* (uRads).
     uint256 public registrationFeeRad = 1e18;
@@ -47,42 +38,26 @@ contract Registrar {
         ENS _ens,
         bytes32 ethDomainNameHash,
         uint256 ethDomainTokenId,
-        address _oracleAddress,
-        address _exchangeAddress,
         ERC20Burnable _rad,
         address adminAddress
     ) {
         ens = _ens;
-        oracleAddress = _oracleAddress;
-        exchangeAddress = _exchangeAddress;
         rad = _rad;
         domain = ethDomainNameHash;
         tokenId = ethDomainTokenId;
         admin = adminAddress;
     }
 
-    /// Register a subdomain using ether.
-    function registerEth(string memory, address) public payable {
-        revert("Registrar::registerEth: Registration using ETH is not yet available");
-    }
-
     /// Register a subdomain using radicle tokens.
     function registerRad(string memory name, address owner) public {
-        uint256 fee = registrationFeeRad;
+        uint256 fee   = registrationFeeRad;
+        bytes32 label = keccak256(bytes(name));
 
-        require(rad.balanceOf(msg.sender) >= fee, "Transaction includes registration fee");
-        require(valid(name), "Name must be valid");
-
-        _register(keccak256(bytes(name)), owner);
+        require(rad.balanceOf(msg.sender) >= fee, "Registrar::registerRad: insufficient rad balance");
+        require(available(name), "Registrar::registerRad: name has already been registered");
+        require(valid(name), "Registrar::registerRad: invalid name");
 
         rad.burnFrom(msg.sender, fee);
-    }
-
-    function _register(bytes32 label, address owner) private {
-        bytes32 node = namehash(domain, label);
-
-        require(!ens.recordExists(node), "Registrar::_register: name must be available");
-
         ens.setSubnodeOwner(domain, label, owner);
 
         emit NameRegistered(label, owner);
@@ -99,7 +74,7 @@ contract Registrar {
         bytes32 label = keccak256(bytes(name));
         bytes32 node = namehash(domain, label);
 
-        return valid(name) && !ens.recordExists(node);
+        return !ens.recordExists(node);
     }
 
     /// Get the "namehash" of a label.
@@ -107,40 +82,7 @@ contract Registrar {
         return keccak256(abi.encodePacked(parent, label));
     }
 
-    /// Registration fee in ether.
-    function registrationFeeEth() public pure returns (uint256) {
-        revert("Registrar::registrationFeeEth: Registration using ETH is not yet available");
-    }
-
     // ADMIN FUNCTIONS
-
-    /// Set the USD registration fee.
-    function setUsdRegistrationFee(uint256 fee) public adminOnly {
-        registrationFeeUsd = fee;
-    }
-
-    /// Set the radicle registration fee.
-    function setRadRegistrationFee(uint256 fee) public adminOnly {
-        registrationFeeRad = fee;
-    }
-
-    /// Set the price oracle.
-    function setPriceOracle(address _oracleAddress) public adminOnly {
-        require(
-            oracleAddress != address(0),
-            "Registrar::setPriceOracle: oracle address cannot be zero"
-        );
-        oracleAddress = _oracleAddress;
-    }
-
-    /// Set the exchange.
-    function setExchange(address _exchangeAddress) public adminOnly {
-        require(
-            exchangeAddress != address(0),
-            "Registrar::setExchange: exchange address cannot be zero"
-        );
-        exchangeAddress = _exchangeAddress;
-    }
 
     /// Set the owner of the domain.
     function setDomainOwner(address newOwner) public adminOnly {

--- a/contracts/Registrar.sol
+++ b/contracts/Registrar.sol
@@ -130,15 +130,8 @@ contract Registrar {
         emit CommitmentMade(commitment, block.number);
     }
 
-    /// Register a subdomain (with the default resolver and ttl)
-    function register(string calldata name, address owner, uint salt) external {
-        register(name, owner, salt, ens.resolver(radNode), 0);
-    }
-
     /// Register a subdomain (with a custom resolver and ttl)
-    function register(
-        string memory name, address owner, uint salt, address resolver, uint64 ttl
-    ) public {
+    function register(string memory name, address owner, uint salt) public {
         bytes32 label = keccak256(bytes(name));
         bytes32 commitment = commitments.mkCommitment(name, owner, salt);
         uint256 commited = commitments.commited(commitment);
@@ -148,7 +141,7 @@ contract Registrar {
         require(commited != 0, "Registrar::register: must commit before registration");
         require(commited + minCommitmentAge < block.number, "Registrar::register: commitment too new");
 
-        ens.setSubnodeRecord(radNode, label, owner, resolver, ttl);
+        ens.setSubnodeRecord(radNode, label, owner, ens.resolver(radNode), ens.ttl(radNode));
 
         emit NameRegistered(name, label, owner);
     }

--- a/contracts/Registrar.sol
+++ b/contracts/Registrar.sol
@@ -46,11 +46,11 @@ contract Registrar {
     constructor(
         ENS _ens,
         ERC20Burnable _rad,
-        address adminAddress
+        address _admin
     ) {
         ens = _ens;
         rad = _rad;
-        admin = adminAddress;
+        admin = _admin;
     }
 
     // --- PUBLIC METHODS ---

--- a/contracts/Registrar.sol
+++ b/contracts/Registrar.sol
@@ -92,14 +92,11 @@ contract Registrar {
 
     /// Set the owner of the domain.
     function setDomainOwner(address newOwner) public adminOnly {
-        address ethRegistrarAddr = ens.owner(ethNode);
-        require(
-            ethRegistrarAddr != address(0),
-            "Registrar::setDomainOwner: no registrar found on ENS for the 'eth' domain"
-        );
+        IERC721 ethRegistrar = IERC721(ens.owner(ethNode));
+
         ens.setRecord(radNode, newOwner, newOwner, 0);
-        IERC721 ethRegistrar = IERC721(ethRegistrarAddr);
         ethRegistrar.transferFrom(address(this), newOwner, tokenId);
+
         emit DomainOwnershipChanged(newOwner);
     }
 

--- a/contracts/Registrar.sol
+++ b/contracts/Registrar.sol
@@ -130,7 +130,7 @@ contract Registrar {
         emit CommitmentMade(commitment, block.number);
     }
 
-    /// Register a subdomain (with a custom resolver and ttl)
+    /// Register a subdomain
     function register(string calldata name, address owner, uint salt) external {
         bytes32 label = keccak256(bytes(name));
         bytes32 commitment = commitments.mkCommitment(name, owner, salt);

--- a/contracts/Registrar.sol
+++ b/contracts/Registrar.sol
@@ -37,6 +37,9 @@ contract Registrar {
     /// @notice The ownership of the domain was changed
     event DomainOwnershipChanged(address newOwner);
 
+    /// @notice The registration fee was changed
+    event RegistrationFeeChanged(uint amt);
+
     /// Protects admin-only functions.
     modifier adminOnly {
         require(msg.sender == admin, "Registrar: only the admin can perform this action");
@@ -98,6 +101,12 @@ contract Registrar {
         ethRegistrar.transferFrom(address(this), newOwner, tokenId);
 
         emit DomainOwnershipChanged(newOwner);
+    }
+
+    /// Set a new registration fee
+    function setRegistrationFee(uint256 amt) public adminOnly {
+        registrationFeeRad = amt;
+        emit RegistrationFeeChanged(amt);
     }
 
     /// Set a new admin

--- a/contracts/Registrar.sol
+++ b/contracts/Registrar.sol
@@ -131,7 +131,7 @@ contract Registrar {
     }
 
     /// Register a subdomain (with a custom resolver and ttl)
-    function register(string memory name, address owner, uint salt) public {
+    function register(string calldata name, address owner, uint salt) external {
         bytes32 label = keccak256(bytes(name));
         bytes32 commitment = commitments.mkCommitment(name, owner, salt);
         uint256 commited = commitments.commited(commitment);

--- a/contracts/Registrar.sol
+++ b/contracts/Registrar.sol
@@ -40,6 +40,9 @@ contract Registrar {
     /// The Radicle ERC20 token.
     RadicleToken public immutable rad;
 
+    /// @notice EIP-712 name for this contract
+    string public constant NAME = "Registrar";
+
     /// The commitment storage contract
     Commitments public immutable commitments = new Commitments();
 
@@ -57,6 +60,17 @@ contract Registrar {
 
     /// Registration fee in *Radicle* (uRads).
     uint256 public fee = 1e18;
+
+    /// @notice The EIP-712 typehash for the contract's domain
+    bytes32 public constant DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,uint256 chainId,address verifyingContract)");
+
+    /// @notice The EIP-712 typehash for the delegation struct used by the contract
+    bytes32 public constant COMMIT_TYPEHASH =
+        keccak256("Commit(bytes32 commitment,uint256 nonce,uint256 expiry,uint256 submissionFee)");
+
+    /// @notice A record of states for signing / validating signatures
+    mapping(address => uint256) public nonces;
 
     // --- LOGS ---
 
@@ -116,19 +130,44 @@ contract Registrar {
 
     /// Commit to a future name registration
     function commit(bytes32 commitment) public {
-        require(commitments.commited(commitment) == 0, "Registrar::commit: already commited");
-
-        rad.burnFrom(msg.sender, fee);
-        commitments.commit(commitment);
-
-        emit CommitmentMade(commitment, block.number);
+        _commit(msg.sender, commitment);
     }
 
     /// Commit to a future name and submit permit in the same transaction
     function commitWithPermit(bytes32 commitment, address owner, address spender, uint256 value,
                               uint256 deadline, uint8 v, bytes32 r, bytes32 s) external {
         rad.permit(owner, spender, value, deadline, v, r, s);
-        commit(commitment);
+        _commit(msg.sender, commitment);
+    }
+
+    function commitBySig(bytes32 commitment, uint256 nonce, uint256 expiry, uint256 submissionFee, uint8 v, bytes32 r, bytes32 s) public {
+        bytes32 domainSeparator =
+            keccak256(
+                abi.encode(DOMAIN_TYPEHASH, keccak256(bytes(NAME)), getChainId(), address(this))
+            );
+        bytes32 structHash = keccak256(abi.encode(COMMIT_TYPEHASH, commitment, nonce, expiry, submissionFee));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
+        address signatory = ecrecover(digest, v, r, s);
+        require(signatory != address(0), "Registrar::commitBySig: invalid signature");
+        require(nonce == nonces[signatory]++, "Registrar::commitBySig: invalid nonce");
+        require(block.timestamp <= expiry, "Registrar::commitBySig: signature expired");
+        rad.transferFrom(signatory, msg.sender, submissionFee);
+        _commit(signatory, commitment);
+    }
+
+    function commitBySigWithPermit(bytes32 commitment, uint256 nonce, uint256 expiry, uint256 submissionFee, uint8 v, bytes32 r, bytes32 s,
+                                   address owner, address spender, uint256 value, uint256 deadline, uint8 permit_v, bytes32 permit_r, bytes32 permit_s) public {
+        rad.permit(owner, spender, value, deadline, permit_v, permit_r, permit_s);
+        commitBySig(commitment, nonce, expiry, submissionFee, v, r, s);
+    }
+
+    function _commit(address payer, bytes32 commitment) internal {
+        require(commitments.commited(commitment) == 0, "Registrar::commit: already commited");
+
+        rad.burnFrom(payer, fee);
+        commitments.commit(commitment);
+
+        emit CommitmentMade(commitment, block.number);
     }
 
     /// Register a subdomain
@@ -212,5 +251,14 @@ contract Registrar {
     function setEns(address newEns) public adminOnly {
         ens = ENS(newEns);
         emit EnsChanged(newEns);
+    }
+
+    function getChainId() internal pure returns (uint256) {
+        uint256 chainId;
+        // solhint-disable no-inline-assembly
+        assembly {
+            chainId := chainid()
+        }
+        return chainId;
     }
 }

--- a/contracts/Registrar.sol
+++ b/contracts/Registrar.sol
@@ -39,7 +39,7 @@ contract Registrar {
 
     /// Protects admin-only functions.
     modifier adminOnly {
-        require(msg.sender == admin, "Only the admin can perform this action");
+        require(msg.sender == admin, "Registrar: only the admin can perform this action");
         _;
     }
 
@@ -52,6 +52,8 @@ contract Registrar {
         rad = _rad;
         admin = adminAddress;
     }
+
+    // --- PUBLIC METHODS ---
 
     /// Register a subdomain using radicle tokens.
     function registerRad(string memory name, address owner) public {
@@ -86,7 +88,7 @@ contract Registrar {
         return keccak256(abi.encodePacked(parent, label));
     }
 
-    // ADMIN FUNCTIONS
+    // --- ADMIN METHODS ---
 
     /// Set the owner of the domain.
     function setDomainOwner(address newOwner) public adminOnly {
@@ -102,8 +104,8 @@ contract Registrar {
     }
 
     /// Set a new admin
-    function setAdmin(address _admin) public adminOnly {
-        admin = _admin;
-        emit AdminChanged(_admin);
+    function setAdmin(address newAdmin) public adminOnly {
+        admin = newAdmin;
+        emit AdminChanged(newAdmin);
     }
 }

--- a/contracts/Registrar.sol
+++ b/contracts/Registrar.sol
@@ -40,7 +40,7 @@ contract Registrar {
     // --- DATA ---
 
     /// The ENS registry.
-    ENS public immutable ens;
+    ENS public ens;
 
     /// The Radicle ERC20 token.
     ERC20Burnable public immutable rad;
@@ -85,6 +85,9 @@ contract Registrar {
 
     /// @notice The registration fee was changed
     event TTLChanged(uint64 amt);
+
+    /// @notice The ens registry was updated
+    event EnsChanged(address ens);
 
     /// @notice The commitment timeout was changed
     event CommitmentTimeoutChanged(uint256 amt);
@@ -214,5 +217,11 @@ contract Registrar {
     function setAdmin(address newAdmin) public adminOnly {
         admin = newAdmin;
         emit AdminChanged(newAdmin);
+    }
+
+    /// Set the address for the ENS registry
+    function setEns(address newEns) public adminOnly {
+        ens = ENS(newEns);
+        emit EnsChanged(newEns);
     }
 }

--- a/contracts/Registrar.sol
+++ b/contracts/Registrar.sol
@@ -29,7 +29,13 @@ contract Registrar {
     address public admin;
 
     /// @notice A name was registered.
-    event NameRegistered(bytes32 indexed label, address indexed owner);
+    event NameRegistered(string indexed name, bytes32 indexed label, address indexed owner);
+
+    /// @notice The contract admin was changed
+    event AdminChanged(address newAdmin);
+
+    /// @notice The ownership of the domain was changed
+    event DomainOwnershipChanged(address newOwner);
 
     /// Protects admin-only functions.
     modifier adminOnly {
@@ -59,7 +65,7 @@ contract Registrar {
         rad.burnFrom(msg.sender, fee);
         ens.setSubnodeOwner(radNode, label, owner);
 
-        emit NameRegistered(label, owner);
+        emit NameRegistered(name, label, owner);
     }
 
     /// Check whether a name is valid.
@@ -92,10 +98,12 @@ contract Registrar {
         ens.setRecord(radNode, newOwner, newOwner, 0);
         IERC721 ethRegistrar = IERC721(ethRegistrarAddr);
         ethRegistrar.transferFrom(address(this), newOwner, tokenId);
+        emit DomainOwnershipChanged(newOwner);
     }
 
     /// Set a new admin
     function setAdmin(address _admin) public adminOnly {
         admin = _admin;
+        emit AdminChanged(_admin);
     }
 }

--- a/contracts/Registrar.sol
+++ b/contracts/Registrar.sol
@@ -171,7 +171,6 @@ contract Registrar {
         IERC721 ethRegistrar = IERC721(ens.owner(ethNode));
 
         ens.setOwner(radNode, newOwner);
-        require(ethRegistrar.ownerOf(tokenId) == address(this), "HI");
         ethRegistrar.transferFrom(address(this), newOwner, tokenId);
         commitments.setOwner(newOwner);
 

--- a/contracts/Registrar.sol
+++ b/contracts/Registrar.sol
@@ -78,7 +78,7 @@ contract Registrar {
     function available(string memory name) public view returns (bool) {
         bytes32 label = keccak256(bytes(name));
         bytes32 node = namehash(radNode, label);
-        return !ens.recordExists(node);
+        return ens.owner(node) == address(0);
     }
 
     /// Get the "namehash" of a label.

--- a/contracts/Registrar.sol
+++ b/contracts/Registrar.sol
@@ -6,6 +6,35 @@ import "@ensdomains/ens/contracts/ENS.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20Burnable.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
+// commitments are kept in a seperate contract to allow the state to be reused
+// between different versions of the registrar
+contract Commitments {
+    address public owner;
+    modifier auth { require(msg.sender == owner, "Commitments: unauthorized"); _; }
+    event SetOwner(address usr);
+
+    mapping(bytes32 => uint) public expires;
+
+    constructor() {
+        owner = msg.sender;
+    }
+
+    function setOwner(address usr) external auth {
+        owner = usr;
+        emit SetOwner(usr);
+    }
+
+    function commit(bytes32 commitment, uint deadline) external auth {
+        expires[commitment] = deadline;
+    }
+
+    function mkCommitment(
+        string calldata name, address owner, uint salt
+    ) external pure returns (bytes32) {
+        return keccak256(abi.encodePacked(name, owner, salt));
+    }
+}
+
 contract Registrar {
 
     // --- DATA ---
@@ -16,6 +45,9 @@ contract Registrar {
     /// The Radicle ERC20 token.
     ERC20Burnable public immutable rad;
 
+    /// The commitment storage contract
+    Commitments public immutable commitments = new Commitments();
+
     /// The namehash of the `eth` TLD in the ENS registry, eg. namehash("eth").
     bytes32 public constant ethNode = keccak256(abi.encodePacked(bytes32(0), keccak256("eth")));
 
@@ -25,13 +57,19 @@ contract Registrar {
     /// The token ID for the node in the `eth` TLD, eg. sha256("radicle").
     uint256 public constant tokenId = uint256(keccak256("radicle"));
 
+    /// The maximum time between commiting to a name and registering the name
+    uint256 public commitmentTimeout = 1 days;
+
     /// Registration fee in *Radicle* (uRads).
-    uint256 public registrationFee = 1e18;
+    uint256 public fee = 1e18;
 
     // --- LOGS ---
 
     /// @notice A name was registered.
     event NameRegistered(string indexed name, bytes32 indexed label, address indexed owner);
+
+    /// @notice A commitment was made
+    event CommitmentMade(bytes32 commitment, uint deadline);
 
     /// @notice The contract admin was changed
     event AdminChanged(address newAdmin);
@@ -47,6 +85,15 @@ contract Registrar {
 
     /// @notice The registration fee was changed
     event TTLChanged(uint64 amt);
+
+    /// @notice The commitment timeout was changed
+    event CommitmentTimeoutChanged(uint256 amt);
+
+    // -- MATH --
+
+    function add(uint x, uint y) internal pure returns (uint z) {
+        require((z = x + y) >= x, "Registrar: overflow during addition");
+    }
 
     // --- AUTH ---
 
@@ -73,21 +120,36 @@ contract Registrar {
 
     // --- USER FACING METHODS ---
 
+    /// Commit to a future name registration
+    function commit(bytes32 commitment) external {
+        uint deadline = add(block.timestamp, commitmentTimeout);
+        require(commitments.expires(commitment) == 0, "Registrar::commit: already commited");
+
+        rad.burnFrom(msg.sender, fee);
+        commitments.commit(commitment, deadline);
+
+        emit CommitmentMade(commitment, deadline);
+    }
+
     /// Register a subdomain (with the default resolver and ttl)
-    function register(string memory name, address owner) public {
-        register(name, owner, ens.resolver(radNode), 0);
+    function register(string calldata name, address owner, uint salt) external {
+        register(name, owner, salt, ens.resolver(radNode), 0);
     }
 
     /// Register a subdomain (with a custom resolver and ttl)
-    function register(string memory name, address owner, address resolver, uint64 ttl) public {
-        uint256 fee   = registrationFee;
+    function register(
+        string memory name, address owner, uint salt, address resolver, uint64 ttl
+    ) public {
         bytes32 label = keccak256(bytes(name));
+        bytes32 commitment = commitments.mkCommitment(name, owner, salt);
+        uint256 expiry = commitments.expires(commitment);
 
+        require(expiry != 0, "Registrar::register: must commit before registration");
+        require(expiry > block.timestamp, "Registrar::register: commitment expired");
         require(rad.balanceOf(msg.sender) >= fee, "Registrar::register: insufficient rad balance");
         require(available(name), "Registrar::register: name has already been registered");
         require(valid(name), "Registrar::register: invalid name");
 
-        rad.burnFrom(msg.sender, fee);
         ens.setSubnodeRecord(radNode, label, owner, resolver, ttl);
 
         emit NameRegistered(name, label, owner);
@@ -119,11 +181,18 @@ contract Registrar {
 
         ens.setOwner(radNode, newOwner);
         ethRegistrar.transferFrom(address(this), newOwner, tokenId);
+        commitments.setOwner(newOwner);
 
         emit DomainOwnershipChanged(newOwner);
     }
 
-    /// Set a new resolver for radicle.eth
+    /// Set the commitment timeout
+    function setCommitmentTimeout(uint256 amt) public adminOnly {
+        commitmentTimeout = amt;
+        emit CommitmentTimeoutChanged(amt);
+    }
+
+    /// Set a new resolver for radicle.eth.
     function setDomainResolver(address resolver) public adminOnly {
         ens.setResolver(radNode, resolver);
         emit ResolverChanged(resolver);
@@ -137,7 +206,7 @@ contract Registrar {
 
     /// Set a new registration fee
     function setRegistrationFee(uint256 amt) public adminOnly {
-        registrationFee = amt;
+        fee = amt;
         emit RegistrationFeeChanged(amt);
     }
 

--- a/contracts/Registrar.sol
+++ b/contracts/Registrar.sol
@@ -115,7 +115,7 @@ contract Registrar {
     // --- USER FACING METHODS ---
 
     /// Commit to a future name registration
-    function commit(bytes32 commitment) external {
+    function commit(bytes32 commitment) public {
         require(commitments.commited(commitment) == 0, "Registrar::commit: already commited");
 
         rad.burnFrom(msg.sender, fee);
@@ -128,12 +128,7 @@ contract Registrar {
     function commitWithPermit(bytes32 commitment, address owner, address spender, uint256 value,
                               uint256 deadline, uint8 v, bytes32 r, bytes32 s) external {
         rad.permit(owner, spender, value, deadline, v, r, s);
-
-        rad.burnFrom(msg.sender, fee);
-        commitments.commit(commitment);
-
-        emit CommitmentMade(commitment, block.number);
-
+        commit(commitment);
     }
 
     /// Register a subdomain

--- a/contracts/Registrar.sol
+++ b/contracts/Registrar.sol
@@ -73,8 +73,13 @@ contract Registrar {
 
     // --- USER FACING METHODS ---
 
-    /// Register a subdomain using radicle tokens.
+    /// Register a subdomain (with the default resolver and ttl)
     function registerRad(string memory name, address owner) public {
+        registerRad(name, owner, ens.resolver(radNode), 0);
+    }
+
+    /// Register a subdomain (with a custom resolver and ttl)
+    function registerRad(string memory name, address owner, address resolver, uint64 ttl) public {
         uint256 fee   = registrationFeeRad;
         bytes32 label = keccak256(bytes(name));
 
@@ -83,7 +88,7 @@ contract Registrar {
         require(valid(name), "Registrar::registerRad: invalid name");
 
         rad.burnFrom(msg.sender, fee);
-        ens.setSubnodeOwner(radNode, label, owner);
+        ens.setSubnodeRecord(radNode, label, owner, resolver, ttl);
 
         emit NameRegistered(name, label, owner);
     }

--- a/contracts/Registrar.sol
+++ b/contracts/Registrar.sol
@@ -94,12 +94,6 @@ contract Registrar {
     /// @notice The minimum age for a commitment was changed
     event MinCommitmentAgeChanged(uint256 amt);
 
-    // -- MATH --
-
-    function add(uint x, uint y) internal pure returns (uint z) {
-        require((z = x + y) >= x, "Registrar: overflow during addition");
-    }
-
     // --- AUTH ---
 
     /// The contract admin who can set fees.

--- a/contracts/tests/RadicleTests.t.sol
+++ b/contracts/tests/RadicleTests.t.sol
@@ -11,7 +11,6 @@ import {Registrar, Commitments} from "../Registrar.sol";
 
 import {ENS}           from "@ensdomains/ens/contracts/ENS.sol";
 import {ENSRegistry}   from "@ensdomains/ens/contracts/ENSRegistry.sol";
-import {ERC20Burnable} from "@openzeppelin/contracts/token/ERC20/ERC20Burnable.sol";
 import {IERC721}       from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
 import {DSTest} from "ds-test/test.sol";
@@ -219,8 +218,9 @@ contract RegistrarRPCTests is DSTest {
         rad = new RadicleToken(address(this));
         registrar = new Registrar(
             ens,
-            ERC20Burnable(address(rad)),
-            address(this)
+            rad,
+            address(this),
+            50
         );
 
         // make the registrar the owner of the radicle.eth domain
@@ -298,8 +298,9 @@ contract RegistrarRPCTests is DSTest {
 
         Registrar registrar2 = new Registrar(
             ens,
-            ERC20Burnable(address(rad)),
-            address(this)
+            rad,
+            address(this),
+            50
         );
         registrar.setDomainOwner(address(registrar2));
         registerWith(registrar2, name);
@@ -340,7 +341,7 @@ contract RegistrarRPCTests is DSTest {
     function registerWith(Registrar reg, string memory name, uint salt) internal {
         uint preBal = rad.balanceOf(address(this));
 
-        bytes32 commitment = reg.commitments().mkCommitment(name, address(this), salt);
+        bytes32 commitment = keccak256(abi.encodePacked(name, address(this), salt));
         rad.approve(address(reg), uint(-1));
 
         reg.commit(commitment);

--- a/contracts/tests/RadicleTests.t.sol
+++ b/contracts/tests/RadicleTests.t.sol
@@ -220,7 +220,9 @@ contract RegistrarRPCTests is DSTest {
             ens,
             rad,
             address(this),
-            50
+            50,
+            domain,
+            tokenId
         );
 
         // make the registrar the owner of the radicle.eth domain
@@ -300,7 +302,9 @@ contract RegistrarRPCTests is DSTest {
             ens,
             rad,
             address(this),
-            50
+            50,
+            domain,
+            tokenId
         );
         registrar.setDomainOwner(address(registrar2));
         registerWith(registrar2, name);

--- a/contracts/tests/RadicleTests.t.sol
+++ b/contracts/tests/RadicleTests.t.sol
@@ -7,7 +7,8 @@ import {Governor}      from "../Governance/Governor.sol";
 import {Timelock}      from "../Governance/Timelock.sol";
 import {Treasury}      from "../Governance/Treasury.sol";
 import {VestingToken}  from "../Governance/VestingToken.sol";
-import {Registrar}     from "../Registrar.sol";
+import {Registrar, Commitments} from "../Registrar.sol";
+
 import {ENS}           from "@ensdomains/ens/contracts/ENS.sol";
 import {ENSRegistry}   from "@ensdomains/ens/contracts/ENSRegistry.sol";
 import {ERC20Burnable} from "@openzeppelin/contracts/token/ERC20/ERC20Burnable.sol";
@@ -218,10 +219,6 @@ contract RegistrarRPCTests is DSTest {
         rad = new RadicleToken(address(this));
         registrar = new Registrar(
             ens,
-            domain,
-            tokenId,
-            address(0), // irrelevant in this version
-            address(0), // irrelevant in this version
             ERC20Burnable(address(rad)),
             address(this)
         );
@@ -251,6 +248,7 @@ contract RegistrarRPCTests is DSTest {
             0x27a5c9c1f678324d928c72a6ff8a66d3c79aa98b4c10804760d4542336658cc7,
             bytes32(uint(1))
         );
+
     }
 
     // --- tests ---
@@ -282,13 +280,13 @@ contract RegistrarRPCTests is DSTest {
         if (bytes(name).length == 0) return;
         if (bytes(name).length > 32) return;
         bytes32 node = Utils.namehash([name, "radicle", "eth"]);
-        registerWith(registrar, name);
+        registerWith(registrar, name, 666);
 
         ens.setOwner(node, address(0));
         assertEq(ens.owner(node), address(0));
         assertTrue(ens.recordExists(node));
 
-        registerWith(registrar, name);
+        registerWith(registrar, name, 667);
         assertEq(ens.owner(node), address(this));
     }
 
@@ -300,10 +298,6 @@ contract RegistrarRPCTests is DSTest {
 
         Registrar registrar2 = new Registrar(
             ens,
-            domain,
-            tokenId,
-            address(0), // irrelevant in this version
-            address(0), // irrelevant in this version
             ERC20Burnable(address(rad)),
             address(this)
         );
@@ -340,10 +334,18 @@ contract RegistrarRPCTests is DSTest {
     // --- helpers ---
 
     function registerWith(Registrar reg, string memory name) internal {
+        registerWith(reg, name, 42069);
+    }
+
+    function registerWith(Registrar reg, string memory name, uint salt) internal {
         uint preBal = rad.balanceOf(address(this));
 
+        bytes32 commitment = reg.commitments().mkCommitment(name, address(this), salt);
         rad.approve(address(reg), uint(-1));
-        reg.registerRad(name, address(this));
+
+        reg.commit(commitment);
+        hevm.roll(block.number + 100);
+        reg.register(name, address(this), salt);
 
         assertEq(rad.balanceOf(address(this)), preBal - 1 ether);
     }


### PR DESCRIPTION
This should address all the issues / improvements with the registrar we found in the report. In summary:

- removed unused code
- added logs for all state changes
- account for ens fallback
- do not set resolver and ttl when migrating to a new registrar
- allow admin control over resolver & ttl values
- set resolver and ttl for subdomains
- give admin control over the ens registry address
- introduce a commit / reveal scheme for name registration

The changes here are relatively substantial (+149/-83) in the registrar, so this needs a lot more testing and review.

Most of the above changes are self contained in their own commit, so you might find it helpful to review commit by commit.